### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/test/test.json
+++ b/test/test.json
@@ -85,7 +85,7 @@
         "Handler": "index.build",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300
       }
     },
@@ -98,7 +98,7 @@
         "Handler": "index.zip",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300
       }
     },
@@ -111,7 +111,7 @@
         "Handler": "index.clear",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300
       }
     },

--- a/workshops/reinvent2018/templates/solarflare-master.yaml
+++ b/workshops/reinvent2018/templates/solarflare-master.yaml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ../code/solarflare/
       Handler: app.lambdaHandler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt SolarFlareFunctionRole.Arn
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:

--- a/workshops/reinvent2019/templates/solarflare-master.yaml
+++ b/workshops/reinvent2019/templates/solarflare-master.yaml
@@ -37,7 +37,7 @@ Resources:
     Properties:
       CodeUri: ../code/solarflare/
       Handler: app.lambdaHandler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt SolarFlareFunctionRole.Arn
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:


### PR DESCRIPTION
CloudFormation templates in aws-ai-qna-bot have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.