### PR TITLE
replaces all versions of nodejs to 10.x -

### DIFF
--- a/templates/examples/extensions/README.md
+++ b/templates/examples/extensions/README.md
@@ -43,5 +43,5 @@ from Content Designer.
 
 ### NOTES
 - The extensions Makefile creates separate zip packages for each separate Lambda hook function 
-- Lambda hook functions use nodejs8.10 or python3.6 only at this time
+- Lambda hook functions use nodejs10.x or python3.6 only at this time
 - Lambda hook functions will be allocated 2048MB memory (defined in index.js)

--- a/test/cfn/test.js
+++ b/test/cfn/test.js
@@ -320,7 +320,7 @@ function lambda(name){
         "Handler": "index."+name,
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LambdaRole","Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300
       }
     }

--- a/workshops/reinvent2018/templates/public.json
+++ b/workshops/reinvent2018/templates/public.json
@@ -45,7 +45,7 @@
         "Handler": "index.handler",
         "MemorySize": "3008",
         "Role": {"Fn::GetAtt": ["CFNLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -72,7 +72,7 @@
         "Handler": "index.handler",
         "MemorySize": "3008",
         "Role": {"Fn::GetAtt": ["CFNLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -405,7 +405,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -591,7 +591,7 @@
         "Handler": "index.resource",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -962,7 +962,7 @@
         "Handler": "index.step",
         "MemorySize": "320",
         "Role": {"Fn::GetAtt": ["ExportRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Export"}]
       }
@@ -1099,7 +1099,7 @@
         "Handler": "index.start",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["ImportRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Import"}]
       }
@@ -1122,7 +1122,7 @@
         "Handler": "index.step",
         "MemorySize": "320",
         "Role": {"Fn::GetAtt": ["ImportRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Import"}]
       }
@@ -1396,7 +1396,7 @@
         "Handler": "index.handler",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["FulfillmentLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Fulfillment"}]
       }
@@ -1505,7 +1505,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexBuildLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -1526,7 +1526,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexBuildLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -1547,7 +1547,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexBuildLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -1763,7 +1763,7 @@
         "Handler": "index.utterances",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -1787,7 +1787,7 @@
         "Handler": "index.qid",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -1813,7 +1813,7 @@
         "Handler": "index.cleanmetrics",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -1857,7 +1857,7 @@
         "Handler": "index.logging",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESLoggingLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Logging"}]
       }
@@ -1881,7 +1881,7 @@
         "Handler": "index.query",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Query"}]
       }
@@ -1906,7 +1906,7 @@
         "Handler": "index.handler",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -2021,7 +2021,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -2042,7 +2042,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -2637,7 +2637,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["SchemaLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -3843,7 +3843,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["S3ListLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -4257,7 +4257,7 @@
         "Handler": "index.documents",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["S3ListLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -4271,7 +4271,7 @@
         "Handler": "index.photos",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["S3ListLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -4493,7 +4493,7 @@
           }
         },
         "Role": {"Fn::GetAtt": ["SignupLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Cognito"}]
       }
@@ -4514,7 +4514,7 @@
           }
         },
         "Role": {"Fn::GetAtt": ["SignupLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Cognito"}]
       }

--- a/workshops/reinvent2019/templates/public.json
+++ b/workshops/reinvent2019/templates/public.json
@@ -45,7 +45,7 @@
         "Handler": "index.handler",
         "MemorySize": "3008",
         "Role": {"Fn::GetAtt": ["CFNLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -72,7 +72,7 @@
         "Handler": "index.handler",
         "MemorySize": "3008",
         "Role": {"Fn::GetAtt": ["CFNLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -405,7 +405,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -591,7 +591,7 @@
         "Handler": "index.resource",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "CustomResource"}]
       }
@@ -962,7 +962,7 @@
         "Handler": "index.step",
         "MemorySize": "320",
         "Role": {"Fn::GetAtt": ["ExportRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Export"}]
       }
@@ -1099,7 +1099,7 @@
         "Handler": "index.start",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["ImportRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Import"}]
       }
@@ -1122,7 +1122,7 @@
         "Handler": "index.step",
         "MemorySize": "320",
         "Role": {"Fn::GetAtt": ["ImportRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Import"}]
       }
@@ -1396,7 +1396,7 @@
         "Handler": "index.handler",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["FulfillmentLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Fulfillment"}]
       }
@@ -1505,7 +1505,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexBuildLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -1526,7 +1526,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexBuildLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -1547,7 +1547,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexBuildLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -1763,7 +1763,7 @@
         "Handler": "index.utterances",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -1787,7 +1787,7 @@
         "Handler": "index.qid",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -1813,7 +1813,7 @@
         "Handler": "index.cleanmetrics",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -1857,7 +1857,7 @@
         "Handler": "index.logging",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESLoggingLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Logging"}]
       }
@@ -1881,7 +1881,7 @@
         "Handler": "index.query",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Query"}]
       }
@@ -1906,7 +1906,7 @@
         "Handler": "index.handler",
         "MemorySize": "1408",
         "Role": {"Fn::GetAtt": ["ESProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Service"}]
       }
@@ -2021,7 +2021,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -2042,7 +2042,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["LexProxyLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -2637,7 +2637,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["SchemaLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -3843,7 +3843,7 @@
         "Handler": "index.handler",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["S3ListLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -4257,7 +4257,7 @@
         "Handler": "index.documents",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["S3ListLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -4271,7 +4271,7 @@
         "Handler": "index.photos",
         "MemorySize": "128",
         "Role": {"Fn::GetAtt": ["S3ListLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Api"}]
       }
@@ -4493,7 +4493,7 @@
           }
         },
         "Role": {"Fn::GetAtt": ["SignupLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Cognito"}]
       }
@@ -4514,7 +4514,7 @@
           }
         },
         "Role": {"Fn::GetAtt": ["SignupLambdaRole", "Arn"]},
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300,
         "Tags": [{"Key": "Type", "Value": "Cognito"}]
       }


### PR DESCRIPTION
Closes #158 

Replaces nodejs 8.10 with nodejs 10.x as the runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
