### PR TITLE
Customisable stackNamePrefix in config

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -1,8 +1,11 @@
 /*
 Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 Licensed under the Amazon Software License (the "License"). You may not use this file
 except in compliance with the License. A copy of the License is located at
+
 http://aws.amazon.com/asl/
+
 or in the "license" file accompanying this file. This file is distributed on an "AS IS"
 BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the
 License for the specific language governing permissions and limitations under the License.

--- a/bin/config.js
+++ b/bin/config.js
@@ -1,11 +1,8 @@
 /*
 Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
 Licensed under the Amazon Software License (the "License"). You may not use this file
 except in compliance with the License. A copy of the License is located at
-
 http://aws.amazon.com/asl/
-
 or in the "license" file accompanying this file. This file is distributed on an "AS IS"
 BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the
 License for the specific language governing permissions and limitations under the License.
@@ -17,7 +14,8 @@ module.exports={
     "publicBucket":"aws-bigdata-blog",
     "publicPrefix":"artifacts/aws-ai-qna-bot",
     "devEmail":"",
-    "namespace":"dev"
+    "namespace":"dev",
+    "stackNamePrefix":"QNA"
 }
 
 if (require.main === module) {

--- a/bin/name.js
+++ b/bin/name.js
@@ -59,9 +59,9 @@ function run(stack,options={}){
     }
 
     if(options.prefix){
-        return `QNA-${full}`
+        return `${config.stackNamePrefix}-${full}`
     }else{
-        return `QNA-${full}-${increment}` 
+        return `${config.stackNamePrefix}-${full}-${increment}`
     }
 
     function set(value){

--- a/lambda/proxy-es/lib/HANDLEBARS_README.md
+++ b/lambda/proxy-es/lib/HANDLEBARS_README.md
@@ -40,7 +40,7 @@ QnABot exposes the following content to the Handlebars context:
 |SessionAttributes._name_          | all session attributes are available to the handlebars context |
 
 ## Helpers
-You can use any [built-in handlerbars helpers](https://handlebarsjs.com/builtin_helpers.html).  
+You can use any [built-in handlerbars helpers](https://handlebarsjs.com/guide/builtin-helpers.html#if).  
 QnABot also provides these additional helpers:
 
 |Helper                  | Descr                                      | Example                                                                                     |

--- a/lambda/proxy-es/lib/HANDLEBARS_README.md
+++ b/lambda/proxy-es/lib/HANDLEBARS_README.md
@@ -40,7 +40,7 @@ QnABot exposes the following content to the Handlebars context:
 |SessionAttributes._name_          | all session attributes are available to the handlebars context |
 
 ## Helpers
-You can use any [built-in handlerbars helpers](https://handlebarsjs.com/guide/builtin-helpers.html#if).  
+You can use any [built-in handlerbars helpers](https://handlebarsjs.com/guide/builtin-helpers.html).  
 QnABot also provides these additional helpers:
 
 |Helper                  | Descr                                      | Example                                                                                     |


### PR DESCRIPTION
*Issue #, if available:*
#160 
Allow CloudFormation to create stacks and assets with names other than "QNA-..."

*Description of changes:*
Added 'stackNamePrefix' param to config.json, defaulted to 'QNA', that bin/name.js can use to generate StackNames and other assets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
