### PR TITLE
Change upload scripts to unset environment variable if instance profi…

### DIFF
--- a/bin/URL.sh
+++ b/bin/URL.sh
@@ -1,6 +1,8 @@
 #! /bin/bash 
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export AWS_PROFILE=$(node -e "console.log(require('$__dirname'+'/../config').profile)")
+# If profile specified from config file does not exist, allow cli to move on to using instance profile
+aws configure get aws_access_key_id --profile $AWS_PROFILE || unset AWS_PROFILE
 export AWS_DEFAULT_REGION=$(node -e "console.log(require('$__dirname'+'/../config').region)")
 
 OUTPUT=$($__dirname/exports.js dev/bootstrap)

--- a/bin/update-public.sh
+++ b/bin/update-public.sh
@@ -1,6 +1,8 @@
 #! /bin/bash 
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export AWS_PROFILE=$(node -e "console.log(require('$__dirname'+'/../config').profile)")
+# If profile specified from config file does not exist, allow cli to move on to using instance profile
+aws configure get aws_access_key_id --profile $AWS_PROFILE || unset AWS_PROFILE
 export AWS_DEFAULT_REGION=$(node -e "console.log(require('$__dirname'+'/../config').region)")
 
 OUTPUT=$($__dirname/exports.js dev/bootstrap)

--- a/bin/upload.sh
+++ b/bin/upload.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export AWS_PROFILE=$(node -e "console.log(require('$__dirname'+'/../config').profile)")
+# If profile specified from config file does not exist, allow cli to move on to using instance profile
+aws configure get aws_access_key_id --profile $AWS_PROFILE || unset AWS_PROFILE
 export AWS_DEFAULT_REGION=$(node -e "console.log(require('$__dirname'+'/../config').region)")
 
 OUTPUT=$($__dirname/exports.js dev/bootstrap)


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Query for profile's access key and if it fails, unset profile environment variable. This causes AWS CLI to go to the next order of precedence.

https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#config-settings-and-precedence

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
