### PR TITLE
remove .DS_store files from bootstrap S3 upload

### DIFF
--- a/templates/export/index.js
+++ b/templates/export/index.js
@@ -2,7 +2,7 @@ var fs=require('fs')
 var _=require('lodash')
 
 var files=fs.readdirSync(`${__dirname}`)
-    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs/))
+    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs|.DS_Store/))
     .map(x=>require(`./${x}`))
 
 module.exports={

--- a/templates/export/resources.js
+++ b/templates/export/resources.js
@@ -2,7 +2,7 @@ var fs=require('fs')
 var _=require('lodash')
 
 var files=fs.readdirSync(`${__dirname}`)
-    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs/))
+    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs|.DS_Store/))
     .map(x=>require(`./${x}`))
 
 module.exports=Object.assign(

--- a/templates/import/index.js
+++ b/templates/import/index.js
@@ -2,7 +2,7 @@ var fs=require('fs')
 var _=require('lodash')
 
 var files=fs.readdirSync(`${__dirname}`)
-    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs/))
+    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs|.DS_Store/))
     .map(x=>require(`./${x}`))
 
 module.exports={

--- a/templates/master/dashboard/lambdas.js
+++ b/templates/master/dashboard/lambdas.js
@@ -3,7 +3,7 @@ var _=require('lodash')
 var util=require('./util')
 
 var files=fs.readdirSync(`${__dirname}/..`)
-    .filter(x=>!x.match(/README.md|Makefile|dashboard|index|test/))
+    .filter(x=>!x.match(/README.md|Makefile|dashboard|index|test|.DS_Store/))
     .map(x=>require(`../${x}`))
     
 var lambdas={}

--- a/templates/master/index.js
+++ b/templates/master/index.js
@@ -2,7 +2,7 @@ var fs=require('fs')
 var _=require('lodash')
 
 var files=fs.readdirSync(`${__dirname}`)
-    .filter(x=>!x.match(/README.md|Makefile|index|test/))
+    .filter(x=>!x.match(/README.md|Makefile|index|test|.DS_Store/))
     .map(x=>require(`./${x}`))
 
 module.exports={

--- a/templates/master/lambda.js
+++ b/templates/master/lambda.js
@@ -2,7 +2,7 @@ var fs=require('fs')
 var _=require('lodash')
 
 var files=fs.readdirSync(`${__dirname}`)
-    .filter(x=>!x.match(/README.md|Makefile|dashboard|index|test/))
+    .filter(x=>!x.match(/README.md|Makefile|dashboard|index|test|.DS_Store/))
     .map(x=>require(`./${x}`))
     
 var lambdas=[]

--- a/templates/testall/index.js
+++ b/templates/testall/index.js
@@ -2,7 +2,7 @@ var fs=require('fs')
 var _=require('lodash')
 
 var files=fs.readdirSync(`${__dirname}`)
-    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs/))
+    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs|.DS_Store/))
     .map(x=>require(`./${x}`))
 
 module.exports={

--- a/templates/testall/resources.js
+++ b/templates/testall/resources.js
@@ -2,7 +2,7 @@ var fs=require('fs')
 var _=require('lodash')
 
 var files=fs.readdirSync(`${__dirname}`)
-    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs/))
+    .filter(x=>!x.match(/README.md|Makefile|index|test|outputs|.DS_Store/))
     .map(x=>require(`./${x}`))
 
 module.exports=Object.assign(


### PR DESCRIPTION
*Issue #, if available:*
remove .DS_store files being uploaded to S3 artifacts during bootstrapping (handy for devs using Macs and local development)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
