### PR TITLE
Updating $root so it works with custom domains

### DIFF
--- a/templates/master/routes/root/info.vm
+++ b/templates/master/routes/root/info.vm
@@ -1,4 +1,4 @@
-#set ( $root="https://${context.domainName}/${context.stage}")
+#set ( $root="https://${!context.domainName}/${!context.stage}")
 
 {
     "region":"${!stageVariables.Region}",
@@ -31,10 +31,10 @@
             "href":"$root/examples/documents"
         },
         "DesignerLogin":{
-            "href":"$stageVariables.DesignerLoginUrl"
+            "href":"$root/pages/designer"
         },
         "ClientLogin":{
-            "href":"$stageVariables.ClientLoginUrl"
+            "href":"$root/static/client.html"
         },
         "CognitoEndpoint":{
             "href":"$stageVariables.CognitoEndpoint"
@@ -47,4 +47,3 @@
         }
     }
 }
-

--- a/templates/master/routes/root/info.vm
+++ b/templates/master/routes/root/info.vm
@@ -1,4 +1,4 @@
-#set ( $root="https://${!context.apiId}.execute-api.${!stageVariables.Region}.amazonaws.com/${!context.stage}")
+#set ( $root="https://${context.domainName}/${context.stage}")
 
 {
     "region":"${!stageVariables.Region}",


### PR DESCRIPTION
Updating $root to use ${context.domainName} so it maps API Gateway to both custom domains and standard gateways.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
