### PR TITLE
Feature/alexa reprompt

### DIFF
--- a/lambda/fulfillment/lib/middleware/alexa.js
+++ b/lambda/fulfillment/lib/middleware/alexa.js
@@ -119,6 +119,11 @@ exports.parse=async function(req){
     }
     return out
 }
+
+/**
+ * @see https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html#response-format
+ * 
+ */
 exports.assemble=function(request,response){
     return {
         version:'1.0',
@@ -140,6 +145,13 @@ exports.assemble=function(request,response){
                 type:"Simple",
                 title:_.get(response,"card.title") || request.question || "Image",
                 content:_.has(response.card,'subTitle')? response.card.subTitle +"\n\n" + response.plainMessage:response.plainMessage
+            },
+            reprompt: {
+                outputSpeech: {
+                  type: 'PlainText',
+                  text: 'Test Reprompt here',
+                  playBehavior: 'REPLACE_ENQUEUED'            
+                }
             },
             shouldEndSession:false
         },

--- a/lambda/fulfillment/lib/middleware/alexa.js
+++ b/lambda/fulfillment/lib/middleware/alexa.js
@@ -147,11 +147,12 @@ exports.assemble=function(request,response){
                 content:_.has(response.card,'subTitle')? response.card.subTitle +"\n\n" + response.plainMessage:response.plainMessage
             },
             reprompt: {
-                outputSpeech: {
-                  type: 'PlainText',
-                  text: 'Test Reprompt here',
-                  playBehavior: 'REPLACE_ENQUEUED'            
-                }
+                outputSpeech: _.pickBy({
+                    type:response.reprompt.type,
+                    text:response.reprompt.type==='PlainText' ? response.reprompt.text : null,
+                    ssml:response.reprompt.type==='SSML' ? response.reprompt.text : null,
+                    playBehavior: 'REPLACE_ENQUEUED',
+                })
             },
             shouldEndSession:false
         },

--- a/lambda/proxy-es/lib/handlebars.js
+++ b/lambda/proxy-es/lib/handlebars.js
@@ -165,6 +165,7 @@ var apply_handlebars = async function (req, res, hit) {
     var a = _.get(hit, "a");
     var markdown = _.get(hit, "alt.markdown");
     var ssml = _.get(hit, "alt.ssml");
+    var rp = _.get(hit, "rp", _.get(req, '_settings.DEFAULT_ALEXA_REPROMPT'));
     var r = _.get(hit, "r");
 
     // catch and log errors before throwing exception.
@@ -201,6 +202,18 @@ var apply_handlebars = async function (req, res, hit) {
             } 
         } catch (e) {
             console.log("ERROR: SSML caused Handlebars exception. Check syntax: ", ssml)
+            throw (e);
+        }
+    }
+    if (rp) {
+        try {
+            var rp_template = Handlebars.compile(rp);
+            hit_out.rp = rp_template(context);
+            if (autotranslate){
+                _.set(hit_out, 'autotranslate.rp', true);
+            } 
+        } catch (e) {
+            console.log("ERROR: reprompt caused Handlebars exception. Check syntax: ", rp)
             throw (e);
         }
     }

--- a/lambda/proxy-es/lib/query.js
+++ b/lambda/proxy-es/lib/query.js
@@ -408,7 +408,6 @@ module.exports = async function (req, res) {
             
             if (rp.includes("<speak>")) {
                 type = 'SSML'
-                rp = rp.replace(/<speak>|<\/speak>/g, "");
                 rp = rp.replace(/\r?\n|\r/g, ' ')
             }
             _.set(res, "reprompt",{type, text : rp })

--- a/lambda/proxy-es/lib/query.js
+++ b/lambda/proxy-es/lib/query.js
@@ -371,7 +371,8 @@ module.exports = async function (req, res) {
                 alt: {
                     markdown: "*[" + msg + "]*  \n",
                     ssml: "<speak>" + msg + "</speak>"
-                }
+                },
+                rp: "[" + _.get(hit, "rp") + "] "
             };
             hit = merge_next(debug_msg, hit) ;
         };
@@ -399,6 +400,19 @@ module.exports = async function (req, res) {
         }
         tmp.altMessages=_.get(res, "result.alt", {});
         _.set(res, "session.appContext",tmp)
+
+        // Add reprompt 
+        var rp = _.get(res, "result.rp");
+        if (rp) {
+            var type = 'PlainText'
+            
+            if (rp.includes("<speak>")) {
+                type = 'SSML'
+                rp = rp.replace(/<speak>|<\/speak>/g, "");
+                rp = rp.replace(/\r?\n|\r/g, ' ')
+            }
+            _.set(res, "reprompt",{type, text : rp })
+        }
 
         if (req._preferredResponseType == "SSML") {
             if (_.get(res, "result.alt.ssml")) {

--- a/lambda/proxy-es/lib/translate.js
+++ b/lambda/proxy-es/lib/translate.js
@@ -39,6 +39,7 @@ exports.translate_hit = async function(hit,usrLang){
     let a = _.get(hit, "a");
     let markdown = _.get(hit, "alt.markdown");
     let ssml = _.get(hit, "alt.ssml");
+    let rp = _.get(hit, "rp");
     let r = _.get(hit, "r");
     // catch and log errors before throwing exception.
     if (a && _.get(hit,'autotranslate.a')) {
@@ -63,6 +64,14 @@ exports.translate_hit = async function(hit,usrLang){
             hit_out.alt.ssml = await get_translation(hit_out.alt.ssml, usrLang);
         } catch (e) {
             console.log("ERROR: SSML caused Translate exception: ", a);
+            throw (e);
+        }
+    }
+    if (rp && _.get(hit,'autotranslate.rp')) {
+        try {
+            hit_out.rp = await get_translation(hit_out.rp, usrLang);
+        } catch (e) {
+            console.log("ERROR: Reprompt caused Translate exception: ", rp);
             throw (e);
         }
     }

--- a/lambda/schema/qna.js
+++ b/lambda/schema/qna.js
@@ -48,11 +48,18 @@ module.exports={
             },
             propertyOrder: 3
         },
+        rp:{
+            type:"string",
+            title:"Alexa Reprompt",
+            description:"Enter the Alexa reprompt to returned if the user does not respond. (SSML autodetection)",
+            maxLength:8000,
+            propertyOrder: 4
+        },
         t:{
             type:"string",
             description:"Assign a topic to this item, to support follow up questions on the same topic. (Sets session attribute 'topic' in response)",
             title:"Topic",
-            propertyOrder: 4
+            propertyOrder: 5
         },
         r:{
             title:"Response card",
@@ -103,14 +110,14 @@ module.exports={
                     propertyOrder: 3
                 }
             },
-            propertyOrder:5,
+            propertyOrder:6,
             required:["title"]
         },
         l:{
             type:"string",
             description:"Enter your lambda function name/ARN to dynamically create or modify answers, or to redirect to a different question.",
             title:"Lambda Hook",
-            propertyOrder:6
+            propertyOrder:7
         },
         args:{
             title:"Lambda Hook Arguments",
@@ -121,13 +128,13 @@ module.exports={
                 type:"string",
                 maxLength:2000
             },
-            propertyOrder:7
+            propertyOrder:8
         },
         elicitResponse:{
             title:"Elicit Response",
             description:"If your answer includes a question to the user, configure QnABot to process and capture the user's response as session attributes.",
             type:"object",
-            propertyOrder:8,
+            propertyOrder:9,
             properties:{
                 responsebot_hook:{
                     title:"Elicit Response: ResponseBot Hook",
@@ -150,17 +157,16 @@ module.exports={
             description:"Automatically move on to another item based on the question string returned by this rule. Rule can be a single-quoted string, e.g. 'next question', or a JavaScript conditional expression that evaluates to a string, e.g. (SessionAttributes.namespace.Yes_No == \"Yes\" ) ? \"Yes question\" : \"No Question\", or a Lambda Function Name or ARN that returns a string specified as \"Lambda::FunctionName\". Function name must start with \"QNA\".",
             type:"string",
             maxLength:4000,
-            propertyOrder:9
+            propertyOrder:10
         },
         next:{
             title:"Guided Navigation: Next QID",
             description:"If applicable, enter the QID of the document(s) that is/are next in the sequence, otherwise leave blank. Be careful; if you set this field to an earlier document in the sequence, you might make your sequence loop forever, which would not be fun!  You can add more QIDs after the first, but they won't do anything at the moment.",
             type:"string",
             maxLength:100,
-            propertyOrder:10
+            propertyOrder:11
         },
     },
     required:["qid","q","a"]
 
 }
-                

--- a/lambda/schema/qna.js
+++ b/lambda/schema/qna.js
@@ -51,7 +51,7 @@ module.exports={
         rp:{
             type:"string",
             title:"Alexa Reprompt",
-            description:"Enter the Alexa reprompt to returned if the user does not respond. (SSML autodetection)",
+            description:"Enter the Alexa reprompt to returned if the user does not respond. (SSML autodetection with &lt;speak&gt;&lt;/speak&gt;)",
             maxLength:8000,
             propertyOrder: 4
         },

--- a/templates/examples/examples/examples/ConditionalChainingDemo.json
+++ b/templates/examples/examples/examples/ConditionalChainingDemo.json
@@ -5,7 +5,7 @@
         ""
       ],
       "next": "",
-      "a": "Hello and Welcome to the demo for QnABot ElicitResponse and Conditional Chaining features. In this demo we will be recommending a space movie based on your age.\nLet's start by getting your name. Just give me your First Name and Last Name please.",
+      "a": "Hello and Welcome to the demo for QNA Bot ElicitResponse and Conditional Chaining features. In this demo we will be recommending a space movie based on your age.\nLet's start by getting your name. Just give me your First Name and Last Name please.",
       "r": {
         "buttons": [
           {
@@ -26,6 +26,7 @@
         "markdown": "Hello and Welcome to the demo for QnABot ElicitResponse and Conditional Chaining features. In this demo we will be recommending a space movie based on your age.\n  \nLet's start by getting your name. Just give me your **First Name** and **Last Name** please.",
         "ssml": ""
       },
+      "rp": "Please say your First Name and Last Name.",
       "conditionalChaining": "'Elicit Age'",
       "l": "",
       "qid": "10.chaining.demo.Name",
@@ -64,6 +65,7 @@
       "alt": {
         "markdown": "<br>\n***Please give us some feedback about this selection?***"
       },
+      "rp": "Have you any feedback?",
       "elicitResponse": {
         "responsebot_hook": "QNAFreeText",
         "response_sessionattr_namespace": "demo.comment"
@@ -112,6 +114,7 @@
         "markdown": "Hi {{SessionAttributes.demo.name.FirstName}}.  \nNow tell me your age (in years) please?",
         "ssml": ""
       },
+      "rp": "How old are you?",
       "conditionalChaining": "(SessionAttributes.demo.age.Age>= 60) ? \"Over 60\" : (SessionAttributes.demo.age.Age< 12) ? \"Under 12\" : \"Between 12 and 60\"",
       "l": "",
       "qid": "20.chaining.demo.Age",

--- a/templates/examples/examples/examples/GreetingHook.json
+++ b/templates/examples/examples/examples/GreetingHook.json
@@ -6,7 +6,7 @@
                 "What are lambda hooks",
                 "What is a lambda hook"
             ],
-            "a": "Lambda Hooks allow you to extend QnABot by returning dynamic answers.",
+            "a": "Lambda Hooks allow you to extend QNA Bot by returning dynamic answers.",
             "l":"QNA:ExampleJSLambdahook"
         }
     ]

--- a/templates/examples/examples/examples/repromptDemo.json
+++ b/templates/examples/examples/examples/repromptDemo.json
@@ -1,0 +1,13 @@
+﻿{
+  "qna": [
+    {
+      "qid": "reprompt.demo",
+      "a": "this is an example  answer with a reprompt. When testing on an Alexa device do not say anything to hear it.",
+      "rp": "<speak><amazon:effect name=\"whispered\">This is the reprompt message</amazon:effect></speak>",
+      "type": "qna",
+      "q": [
+        "test reprompt"
+      ]
+    }
+  ]
+}

--- a/templates/examples/examples/examples/repromptDemo.txt
+++ b/templates/examples/examples/examples/repromptDemo.txt
@@ -1,0 +1,1 @@
+Shows an answer with a SSML reprompt.

--- a/templates/master/default-settings.js
+++ b/templates/master/default-settings.js
@@ -19,6 +19,7 @@ var default_settings = {
     ERRORMESSAGE: "Unfortunately I encountered an error when searching for your answer. Please ask me again later.",
     EMPTYMESSAGE: "You stumped me! Sadly I don't know how to answer your question.",
     DEFAULT_ALEXA_LAUNCH_MESSAGE: "Hello, Please ask a question",
+    DEFAULT_ALEXA_REPROMPT: "Say Goodbye to disconnect, otherwise ask another question.",
     DEFAULT_ALEXA_STOP_MESSAGE: "Goodbye",
     SMS_HINT_REMINDER_ENABLE: "true",
     SMS_HINT_REMINDER: " (Feedback? Reply THUMBS UP or THUMBS DOWN. Ask HELP ME at any time)",

--- a/templates/master/default-settings.js
+++ b/templates/master/default-settings.js
@@ -19,7 +19,7 @@ var default_settings = {
     ERRORMESSAGE: "Unfortunately I encountered an error when searching for your answer. Please ask me again later.",
     EMPTYMESSAGE: "You stumped me! Sadly I don't know how to answer your question.",
     DEFAULT_ALEXA_LAUNCH_MESSAGE: "Hello, Please ask a question",
-    DEFAULT_ALEXA_REPROMPT: "Say Goodbye to disconnect, otherwise ask another question.",
+    DEFAULT_ALEXA_REPROMPT: "Please either answer the question, ask another question or say Goodbye to end the conversation.",
     DEFAULT_ALEXA_STOP_MESSAGE: "Goodbye",
     SMS_HINT_REMINDER_ENABLE: "true",
     SMS_HINT_REMINDER: " (Feedback? Reply THUMBS UP or THUMBS DOWN. Ask HELP ME at any time)",


### PR DESCRIPTION
*Issue #, if available:*
Adding Reprompt functionality for Alexa 

*Description of changes:*
- Content Designer now has an "Alexa Reprompt" input (under "Advanced" accordion menu).
- SSML is supported and autodetected based on existence of `<speak>` tag.
- In multi-language mode, it supports translation. (_*Needs testing*_)
- Supports handlebars processing.
- New 'Settings' value `DEFAULT_ALEXA_REPROMPT : Please either answer the question, ask another question or say Goodbye to end the conversation.`
- Conditional Chaining using `ElicitResponseBots` now supports Reprompts for Alexa. (Lex already implemented by the ElicitResponseBots)
- New `repromptDemo` added to Examples for Content Designer
- Kendra not tested

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
