### PR TITLE
<amazon:effect> Temp Fix for Translate Bug

### DIFF
--- a/lambda/proxy-es/lib/translate.js
+++ b/lambda/proxy-es/lib/translate.js
@@ -16,7 +16,15 @@ async function get_translation(englishText, targetLang){
     const translateClient = new AWS.Translate();
     try {
         console.log("input text:", englishText);
+        const hasAmazonEffectTag = englishText.includes('amazon:effect')
+        if (hasAmazonEffectTag) {
+            console.log("input text has <amazon:effect> tags, override to fix translate bug");
+            englishText.replace(/amazon:effect/g, 'amazon-effect');
+        }
         const translation = await translateClient.translateText(params).promise();
+        if (hasAmazonEffectTag) {
+            translation.TranslatedText.replace(/amazon-effect/g, 'amazon:effect');
+        }
         console.log("translation:", translation);
         return translation.TranslatedText;
     } catch (err) {


### PR DESCRIPTION
When text contains <amazon:effect> tags, the AWS Translate service has a known bug that can cause it to mistranslate. This is a temp fix till the service is patched.