### PR TITLE
Allow deployments using SSO profiles

### DIFF
--- a/source/bin/URL.sh
+++ b/source/bin/URL.sh
@@ -2,7 +2,7 @@
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export AWS_PROFILE=$(node -e "console.log(require('$__dirname'+'/../config.json').profile)")
 # If profile specified from config file does not exist, allow cli to move on to using instance profile
-aws configure get aws_access_key_id --profile $AWS_PROFILE || unset AWS_PROFILE
+aws configure list --profile $AWS_PROFILE || unset AWS_PROFILE
 export AWS_DEFAULT_REGION=$(node -e "console.log(require('$__dirname'+'/../config.json').region)")
 
 OUTPUT=$($__dirname/exports.js dev/bootstrap)

--- a/source/bin/update-public.sh
+++ b/source/bin/update-public.sh
@@ -90,7 +90,7 @@ parse_arguments $@
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export AWS_PROFILE=$(node -e "console.log(require('$__dirname'+'/../config.json').profile)")
 # If profile specified from config file does not exist, allow cli to move on to using instance profile
-aws configure get aws_access_key_id --profile $AWS_PROFILE || unset AWS_PROFILE
+aws configure list --profile $AWS_PROFILE || unset AWS_PROFILE
 export AWS_DEFAULT_REGION=$(node -e "console.log(require('$__dirname'+'/../config.json').region)")
 
 OUTPUT=$($__dirname/exports.js dev/bootstrap)

--- a/source/bin/upload.sh
+++ b/source/bin/upload.sh
@@ -76,7 +76,7 @@ parse_arguments $@
 __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export AWS_PROFILE=$(node -e "console.log(require('$__dirname'+'/../config.json').profile)")
 # If profile specified from config file does not exist, allow cli to move on to using instance profile
-aws configure get aws_access_key_id --profile $AWS_PROFILE || unset AWS_PROFILE
+aws configure list --profile $AWS_PROFILE || unset AWS_PROFILE
 export AWS_DEFAULT_REGION=$(node -e "console.log(require('$__dirname'+'/../config.json').region)")
 
 OUTPUT=$($__dirname/exports.js dev/bootstrap)


### PR DESCRIPTION
The previous logic verified that a profile exists by looking for the configuration value `aws_access_key_id`. This value only exists for for profiles with API keys, so it fails for SSO authenticated profiles.

This commit uses the more generic `aws configure list` command to verify that the profile exists. The command returns 0 if the profile is present, and 255 if it is not.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
