### PR TITLE
Sort the examples in the CF template

### DIFF
--- a/source/templates/examples/examples/index.js
+++ b/source/templates/examples/examples/index.js
@@ -11,6 +11,7 @@ const responsebots_lexv2 = require('./responsebots-lexv2.js').resources;
 const js = fs.readdirSync(`${__dirname}/js`)
     .filter((x) => !x.match(/(.*).(test|fixtures).js/)) // NOSONAR - javascript:S5852 - Cannot expose DOS attacks since this regex is only used during deployment
     .filter((x) => x.match(/(.*).js/)) // NOSONAR - javascript:S5852 - Cannot expose DOS attacks since this regex is only used during deployment
+    .sort()
     .map((file) => {
         const name = file.match(/(.*).js/)[1]; // NOSONAR - javascript:S5852 - Cannot expose DOS attacks since this regex is only used during deployment
         return {
@@ -26,6 +27,7 @@ const py = fs.readdirSync(`${__dirname}/py`, { withFileTypes: true })
     .filter((x) => x.isFile())
     .map((x) => x.name)
     .filter((x) => x.match(/(.*).py/)) // NOSONAR - javascript:S5852 - Cannot expose DOS attacks since this regex is only used during deployment
+    .sort()
     .map((file) => {
         const name = file.match(/(.*).py/)[1]; // NOSONAR - javascript:S5852 - Cannot expose DOS attacks since this regex is only used during deployment
         return {

--- a/source/templates/examples/outputs.js
+++ b/source/templates/examples/outputs.js
@@ -28,7 +28,7 @@ const js_ext = fs.readdirSync(`${__dirname}/extensions/js_lambda_hooks`)
 const py_ext = fs.readdirSync(`${__dirname}/extensions/py_lambda_hooks`)
     .map((name) => `EXT${name}`);
 
-exports.names = js_example.concat(py_example).concat(js_ext).concat(py_ext);
+exports.names = js_example.concat(py_example).concat(js_ext).concat(py_ext).sort();
 
 const out = _.fromPairs(exports.names.map((x) => [x, { Value: { 'Fn::GetAtt': [x, 'Arn'] } }]));
 

--- a/source/templates/master/__snapshots__/index.test.js.snap
+++ b/source/templates/master/__snapshots__/index.test.js.snap
@@ -10884,6 +10884,24 @@ exports.documents = (event, context, callback) => {
                 {
                   "Fn::GetAtt": [
                     "ExamplesStack",
+                    "Outputs.EXTCreateRecentTopicsResponse",
+                  ],
+                },
+                {
+                  "Fn::GetAtt": [
+                    "ExamplesStack",
+                    "Outputs.EXTCustomJSHook",
+                  ],
+                },
+                {
+                  "Fn::GetAtt": [
+                    "ExamplesStack",
+                    "Outputs.EXTCustomPYHook",
+                  ],
+                },
+                {
+                  "Fn::GetAtt": [
+                    "ExamplesStack",
                     "Outputs.ExampleJSLambdaQuiz",
                   ],
                 },
@@ -10927,24 +10945,6 @@ exports.documents = (event, context, callback) => {
                   "Fn::GetAtt": [
                     "ExamplesStack",
                     "Outputs.ExamplePYTHONLambdahello",
-                  ],
-                },
-                {
-                  "Fn::GetAtt": [
-                    "ExamplesStack",
-                    "Outputs.EXTCreateRecentTopicsResponse",
-                  ],
-                },
-                {
-                  "Fn::GetAtt": [
-                    "ExamplesStack",
-                    "Outputs.EXTCustomJSHook",
-                  ],
-                },
-                {
-                  "Fn::GetAtt": [
-                    "ExamplesStack",
-                    "Outputs.EXTCustomPYHook",
                   ],
                 },
               ],
@@ -15661,6 +15661,24 @@ function message(code, name) {
                 {
                   "Fn::GetAtt": [
                     "ExamplesStack",
+                    "Outputs.EXTCreateRecentTopicsResponse",
+                  ],
+                },
+                {
+                  "Fn::GetAtt": [
+                    "ExamplesStack",
+                    "Outputs.EXTCustomJSHook",
+                  ],
+                },
+                {
+                  "Fn::GetAtt": [
+                    "ExamplesStack",
+                    "Outputs.EXTCustomPYHook",
+                  ],
+                },
+                {
+                  "Fn::GetAtt": [
+                    "ExamplesStack",
                     "Outputs.ExampleJSLambdaQuiz",
                   ],
                 },
@@ -15704,24 +15722,6 @@ function message(code, name) {
                   "Fn::GetAtt": [
                     "ExamplesStack",
                     "Outputs.ExamplePYTHONLambdahello",
-                  ],
-                },
-                {
-                  "Fn::GetAtt": [
-                    "ExamplesStack",
-                    "Outputs.EXTCreateRecentTopicsResponse",
-                  ],
-                },
-                {
-                  "Fn::GetAtt": [
-                    "ExamplesStack",
-                    "Outputs.EXTCustomJSHook",
-                  ],
-                },
-                {
-                  "Fn::GetAtt": [
-                    "ExamplesStack",
-                    "Outputs.EXTCustomPYHook",
                   ],
                 },
               ],


### PR DESCRIPTION
The code previously produced CF code from a listing of files from the `fs.readdirSync()` function. The problem is that the order of the files returned by `fs.readdirSync()` is determined by the underlying filesystem implementation, and thus changes from one filesystem to the next.

This was causing the template code to be produced with elements in a different order from one developer to the next. This did not result in any functional difference (or bug) in the template, but it did cause the template tests to fail because the the snapshot verification expects a fixed order.

*Description of changes:*
- Sort the file listings from `source/templates/examples/extensions/js_lambda_hooks`, `source/templates/examples/extensions/py_lambda_hooks`, `source/templates/examples/examples/js`, and `source/templates/examples/examples/py`
- Update the template snapshots to match the sorted order

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
