### PR TITLE
fix to remove regex handling for comprehend detected PII and fix to allow span tags with style attribute with color specification

### DIFF
--- a/source/lambda/es-proxy-layer/lib/sanitizeOutput.js
+++ b/source/lambda/es-proxy-layer/lib/sanitizeOutput.js
@@ -8,15 +8,29 @@ const sanitizeHtml = require('sanitize-html');
 // Sanitize outputs to prevent malicious attacks
 function sanitize(data) {
     const sanitizeParams = {
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['question', 'references', 'chatHistory', 'followUpMessage', 'details', 'summary', 'img']),
-        allowedAttributes: { ...sanitizeHtml.defaults.allowedAttributes, a: ['href'], p: ['style'], span: ['translate'] },
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+            'question',
+            'references',
+            'chatHistory',
+            'followUpMessage',
+            'details',
+            'summary',
+            'img'
+        ]),
+        allowedAttributes: {
+            ...sanitizeHtml.defaults.allowedAttributes,
+            a: ['href'],
+            p: ['style'],
+            span: ['translate', 'style']
+        },
         allowedStyles: {
             p: { 'white-space': [/^pre-line$/] },
+            span: { 'color': [/^#(0x)?[0-9a-f]+$/i, /^rgb\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)$/] }
         },
         allowedSchemesByTag: {
             img: ['https', 'data'],
-            a: ['http', 'https', 'mailto', 'tel'],
-        },
+            a: ['http', 'https', 'mailto', 'tel']
+        }
     };
     const sanitizedData = sanitizeHtml(data, sanitizeParams);
     return sanitizedData;

--- a/source/lambda/qnabot-common-layer/qnabot/logging.js
+++ b/source/lambda/qnabot-common-layer/qnabot/logging.js
@@ -18,10 +18,13 @@ function filter_comprehend_pii(text) {
         return text;
     }
 
-    const regex = process.env.found_comprehend_pii.split(',').map((pii) => `(${pii})`).join('|');
-
-    const re = new RegExp(regex, 'g');
-    return text.replace(re, 'XXXXXX');
+    try {
+        process.env.found_comprehend_pii.split(',').map((pii) => (text = text.split(pii).join('XXXXXX')));
+        return text;
+    } catch (e) {
+        process.env['found_comprehend_pii'] = '';
+        return text;
+    }
 }
 
 function filter(text) {


### PR DESCRIPTION
fix to remove regex handling for comprehend detected PII and fix to allow span tags with style attribute using color specification

*Issue #, if available:*
Issue 895 and part of 869.

*Description of changes:*
1) Remove regx use in logging.js within function filter_comprehend_pii(). This removes the potential exception which was making the current Lambda instance of the fulfillment handler uninvokeable and allows all comprehend detected pii to be removed from the log message.

2) Add appropriate definition in sanitizeOutput.js to allow span tags with the style attribute using a color specification in either #hex or rga format. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
